### PR TITLE
fix([ia]spell): prevent interpretation of ispell pipe-mode instructio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Requires `docker` and `docker-compose` to be installed (tested on Linux).
 ```sh
 $ make build # build container images
 $ make setup # start spellcheckers container
+$ make vendor # install dependencies
 $ make tests-dox
 ```
 

--- a/src/MisspellingHandler/EchoHandler.php
+++ b/src/MisspellingHandler/EchoHandler.php
@@ -11,7 +11,7 @@ class EchoHandler implements MisspellingHandlerInterface
     /**
      * @param MisspellingInterface[] $misspellings
      */
-    public function handle(iterable $misspellings): void
+    public function handle(iterable $misspellings)
     {
         foreach ($misspellings as $misspelling) {
             $output = \Safe\sprintf(

--- a/src/Spellchecker/Aspell.php
+++ b/src/Spellchecker/Aspell.php
@@ -37,7 +37,7 @@ class Aspell implements SpellcheckerInterface
         $process = new Process($cmd->getArgs());
         // Add prefix characters putting Ispell's type of spellcheckers in terse-mode,
         // ignoring correct words and thus speeding up the execution
-        $process->setInput('!' . PHP_EOL . $text . PHP_EOL . '%');
+        $process->setInput('!' . PHP_EOL . Ispell::preprocessInputForPipeMode($text) . PHP_EOL . '%');
 
         $output = ProcessRunner::run($process)->getOutput();
 
@@ -45,7 +45,9 @@ class Aspell implements SpellcheckerInterface
             throw new ProcessHasErrorOutputException($process->getErrorOutput(), $text, $process->getCommandLine());
         }
 
-        return IspellOutputParser::parseMisspellings($output, $context);
+        $misspellings = IspellOutputParser::parseMisspellings($output, $context);
+
+        return Ispell::postprocessMisspellings($misspellings);
     }
 
     public function getBinaryPath(): CommandLine

--- a/tests/Fixtures/Aspell/check.txt
+++ b/tests/Fixtures/Aspell/check.txt
@@ -1,21 +1,50 @@
-@(#) International Ispell Version 3.1.20 (but really Aspell 0.60.6.1)
-& Tigr 34 0: Ti gr, Ti-gr, Tiger, Tier
+@(#) International Ispell Version 3.1.20 (but really Aspell 0.60.7-20110707)
+& Tigr 34 1: Ti gr, Ti-gr, Tiger, Tier, Tigers, Trig, Tire, Tog, Tug, Gr, Tigris, Tr, TGIF, Togo, Taiga, Toga, Trier, Togs, Tugs, Mgr, Dig, Tag, Tic, Terr, Tick, Digs, Tags, Tics, Tiger's, Tog's, Tug's, Dig's, Tag's, Tic's
 *
 *
 
 *
-& theforests 10 3: the forests, the-forests, reforests, theorists, deforests, forests, theorist's, afforests, Forest's, forest's
+& theforests 10 4: the forests, the-forests, reforests, theorists, deforests, forests, theorist's, afforests, Forest's, forest's
 *
 *
 *
 
 *
-& imortal 6 5: immortal, mortal, immortally, immortals, immoral, immortal's
+& imortal 6 6: immortal, mortal, immortally, immortals, immoral, immortal's
 *
 *
-& eey 13 21: eye, EEO, EEC, EEG, eek, eel, Key, bey, fey, hey, key, e'er, e'en
+& eey 13 22: eye, EEO, EEC, EEG, eek, eel, Key, bey, fey, hey, key, e'er, e'en
 
-& CCould 17 0: Could, Cold, Gould, Cloud, Coiled, Cloudy, Coaled, Cooled, Colt, Clod, Cult, Gold, Scold, Mould, Would, Clout, Clued
+& CCould 16 1: Could, Cold, Gould, Cloud, Coiled, Cloudy, Coaled, Cooled, Colt, Clod, Cult, Gold, Scold, Would, Clout, Clued
+*
+*
+*
+*
+
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
+
+*
+*
 *
 *
 *

--- a/tests/Fixtures/Ispell/check.txt
+++ b/tests/Fixtures/Ispell/check.txt
@@ -1,5 +1,5 @@
 @(#) International Ispell Version 3.4.00 8 Feb 2015
-& Tigr 2 0: Tier, Tiger
+& Tigr 3 1: Tier, Tiger, Tigre
 *
 *
 *
@@ -9,18 +9,47 @@
 *
 
 *
-& theforests 2 3: the forests, the-forests
+& theforests 2 4: the forests, the-forests
 *
 *
 *
 
 *
-& imortal 2 5: immortal, mortal
+& imortal 4 6: immortal, i mortal, i-mortal, mortal
 *
 *
-& eey 16 21: bey, dey, eeg, eel, eely, eery, Ely, eye, fey, gey, hey, key, ley, ney, rey, sey
+& eey 16 22: bey, dey, eeg, eek, eel, eely, eery, Ely, eye, fey, gey, hey, key, ley, rey, sey
 
-& CCould 1 0: Could
+& CCould 3 1: Could, C Could, C-Could
+*
+*
+*
+*
+
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
++ A
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
+
+*
+*
 *
 *
 *

--- a/tests/Spellchecker/LanguageToolTest.php
+++ b/tests/Spellchecker/LanguageToolTest.php
@@ -47,21 +47,37 @@ class LanguageToolTest extends TestCase
                         ],
                     ],
                     [
-                        'message' => 'Possible spelling mistake found',
-                        'replacements' => [['value' => 'Could']],
-                        'offset' => 81,
+                        'message' => 'Possible spelling mistake found.',
+                        'shortMessage' => 'Spelling mistake',
+                        'replacements' => [['value' => 'Could', ]],
+                        'offset' => 239,
                         'length' => 6,
                         'context' => [
-                            'text' => '... of the night, What imortal hand or eey CCould frame thy fearful symmetry?',
-                            'offset' => 43,
-                            'length' => 6,
-                        ],
-                        'sentence' => "In theforests of the night,\nWhat imortal hand or eey\nCCould frame thy fearful symmetry?",
+                                'text' => '... &this should not be interpreted either CCould frame thy fearful symmetry?',
+                                'offset' => 43,
+                                'length' => 6,
+                            ],
+                        'sentence' => <<<TEXT
+In theforests of the night,
+What imortal hand or eey
+*This should be spell-checked by aspell and not interpreted as an instruction to add a word to the personal dictionary
+&this should not be interpreted either
+CCould frame thy fearful symmetry?
+TEXT,
+                        'type' => ['typeName' => 'Other', ],
                         'rule' => [
+                            'id' => 'MORFOLOGIK_RULE_EN_US',
                             'description' => 'Possible spelling mistake',
                             'issueType' => 'misspelling',
+                            'category' => [
+                                'id' => 'TYPOS',
+                                'name' => 'Possible Typo',
+                            ],
                         ],
+                        'ignoreForIncompleteSentence' => false,
+                        'contextForSureMatch' => 0,
                     ],
+
                 ],
             ]);
 
@@ -157,7 +173,7 @@ class LanguageToolTest extends TestCase
         $this->assertArrayHasKey('ctx', $misspellings[$lastKey]->getContext());
         $this->assertSame($misspellings[$lastKey]->getWord(), 'CCould');
         $this->assertSame($misspellings[$lastKey]->getOffset(), 0);
-        $this->assertSame($misspellings[$lastKey]->getLineNumber(), 4);
+        $this->assertSame($misspellings[$lastKey]->getLineNumber(), 6);
         $this->assertNotEmpty($misspellings[$lastKey]->getSuggestions());
     }
 

--- a/tests/TextTest.php
+++ b/tests/TextTest.php
@@ -13,6 +13,8 @@ class TextTest extends TestCase
 Tigr, tiger, burning страх.
 In theforests of the night,
 What imortal hand or eey
+*This should be spell-checked by aspell and not interpreted as an instruction to add a word to the personal dictionary
+&this should not be interpreted either
 CCould frame thy fearful symmetry?
 TEXT;
 


### PR DESCRIPTION
…n characters at the beginning of a line

## Description

These changes ensure that the pipe mode of ispall/aspell does not execute unvoluntary instructions.
In pipe mode lines beginning with one of these chars are instruction to the checker :

*,&,@,#,+,!,%,^

 (as stated in http://aspell.net/man-html/Through-A-Pipe.html#Through-A-Pipe)



## Motivation and context

if a line begins with * for instance, the rest of the line will not be spell-checked.
instead it will be considered as a word to be added to the personal dictionary
At best the rest of the line is a lexically valid word and the only effect is that the spell-check is not performed of this line
But if it's not a valid word we have the additional effect of an error being sent to stderr.

ex:

```shell
$ make build 
$ make setup
$ docker-compose run --rm php /bin/bash
$ printf "*Tigr, tiger, burning страх" | aspell -a --encoding=utf-8 --lang=en_US
@(#) International Ispell Version 3.1.20 (but really Aspell 0.60.7-20110707)
Error: The word "Tigr, tiger, burning ?????" is invalid. The character ',' (U+2C) may not appear in the middle of a word.
```

but with the caret oat the beginning of the line:

```shell
$ printf "^*Tigr, tiger, burning страх" | aspell -a --encoding=utf-8 --lang=en_US
@(#) International Ispell Version 3.1.20 (but really Aspell 0.60.7-20110707)
& Tigr 34 2: Ti gr, Ti-gr, Tiger, Tier, Tigers, Trig, Tire, Tog, Tug, Gr, Tigris, Tr, TGIF, Togo, Taiga, Toga, Trier, Togs, Tugs, Mgr, Dig, Tag, Tic, Terr, Tick, Digs, Tags, Tics, Tiger's, Tog's, Tug's, Dig's, Tag's, Tic's
*
*


```

What we want IMHO is that any of these special chars to be ignored and the rest of the line is spell-checked.
The text to spellcheck can contain such first chars in lines, like the * for bulleted-list in markdown.
the ^ instruction is what we need here, it does exactly that, so I propose to add it at the beginning of every input lines.

Once done we have to decrease every offset by one since the caret is taken in account by aspell to compute it.

## How has this been tested?

I added the following lines to the TextTest::CONTENT_STUB :

```
*This should be spell-checked by aspell and not interpreted as an instruction to add a word to the personal dictionary
&this should not be interpreted either
```

## Checklist:

Go over all the following points before making your PR:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

I don't think we have to change the doc for that.

I hope there is not too much to change, if needed I'll be happy to do the modifications.