### PR TITLE
docs: updating documentation, removing stray $ character

### DIFF
--- a/docs/content/01_Getting_Started/02_Quick_Start.md
+++ b/docs/content/01_Getting_Started/02_Quick_Start.md
@@ -4,7 +4,7 @@
 Via Composer
 
 ```sh
-$ composer require tigitz/php-spellchecker
+composer require tigitz/php-spellchecker
 ```
 
 # Usage

--- a/docs/content/03_Spellcheckers/01_Aspell.md
+++ b/docs/content/03_Spellcheckers/01_Aspell.md
@@ -9,21 +9,21 @@ GNU Aspell is available in the default repositories of most Linux distributions,
 On **Arch Linux** and derivatives like **Antergos**, **Manjaro Linux**, run:
 
 ```sh
-$ sudo pacman -S aspell
+sudo pacman -S aspell
 ```
 On **Fedora**:
 ```sh
-$ sudo dnf install aspell
+sudo dnf install aspell
 ```
 On **RHEL**, **CentOS**:
 ```sh
-$ sudo yum install epel-release
+sudo yum install epel-release
 
-$ sudo yum install aspell
+sudo yum install aspell
 ```
 On **Debian**, **Ubuntu**:
 ```sh
-$ sudo apt-get install aspell
+sudo apt-get install aspell
 ```
 
 on **Mac OSX** with **Homebrew**:
@@ -34,24 +34,24 @@ By default, Aspell won’t have any dictionaries. To add a dictionary, for examp
 
 This can also be found in the default repositories. For instance, to add English dictionary on Arch linux, run:
 ```sh
-$ sudo pacman -S aspell-en
+sudo pacman -S aspell-en
 ```
 On **Debian**, **Ubuntu**:
 ```sh
-$ sudo apt-get install aspell-en
+sudo apt-get install aspell-en
 ```
 On **Fedora**:
 ```sh
-$ sudo dnf install aspell-en
+sudo dnf install aspell-en
 ```
 On **RHEL**/**CentOS**:
 ```sh
-$ sudo yum install aspell-en
+sudo yum install aspell-en
 ```
 
 Once installed all dictionaries, you can ensure whether the required dictionaries are available or not using command:
 ```sh
-$ aspell dicts
+aspell dicts
 en
 en-variant_0
 en-variant_1

--- a/docs/content/03_Spellcheckers/02_Hunspell.md
+++ b/docs/content/03_Spellcheckers/02_Hunspell.md
@@ -16,21 +16,21 @@ Hunspell is available in the default repositories of most Linux distributions, s
 On **Arch Linux** and derivatives like **Antergos**, **Manjaro Linux**, run:
 
 ```sh
-$ sudo pacman -S hunspell
+sudo pacman -S hunspell
 ```
 On **Fedora**:
 ```sh
-$ sudo dnf install hunspell
+sudo dnf install hunspell
 ```
 On **RHEL**, **CentOS**:
 ```sh
-$ sudo yum install epel-release
+sudo yum install epel-release
 
 $ sudo yum install hunspell
 ```
 On **Debian**, **Ubuntu**:
 ```sh
-$ sudo apt-get install hunspell
+sudo apt-get install hunspell
 ```
 
 on **Mac OSX** with **Homebrew**:
@@ -41,20 +41,20 @@ By default, Hunspell won’t have any dictionaries. To add a dictionary, for exa
 
 This can also be found in the default repositories. For instance, to add English dictionary on Arch linux, run:
 ```sh
-$ sudo pacman -S hunspell-en-us
+sudo pacman -S hunspell-en-us
 ```
 
 On **Debian**, **Ubuntu**:
 ```sh
-$ sudo apt-get install hunspell-en-us
+sudo apt-get install hunspell-en-us
 ```
 On **Fedora**:
 ```sh
-$ sudo dnf install hunspell-en-us
+sudo dnf install hunspell-en-us
 ```
 On **RHEL**/**CentOS**:
 ```sh
-$ sudo yum install hunspell-en-us
+sudo yum install hunspell-en-us
 ```
 
 on **Mac OSX**:
@@ -63,7 +63,7 @@ Download dictionaries from http://wordlist.aspell.net/dicts/ and put them to `/L
 
 Once installed all dictionaries, you can ensure whether the required dictionaries are available or not using command:
 ```sh
-$ hunspell -D
+hunspell -D
 /usr/share/hunspell/en_US
 ...
 ```

--- a/docs/content/07_Contributing/01_Tests.md
+++ b/docs/content/07_Contributing/01_Tests.md
@@ -9,15 +9,15 @@ The most convenient way to do it is by using Docker and avoid polluting your loc
 Requires `docker` and `docker-compose` to be installed (tested on Linux).
 
 ```sh
-$ make build # build container images
-$ make setup # start spellcheckers container
-$ make tests-dox
+make build # build container images
+make setup # start spellcheckers container
+make tests-dox
 ```
 
 You can also specify PHP version, dependency version target and if you want coverage. Coverage is only supported by PHP 7.2 for now.
 
 ```sh
-$ PHP_VERSION=7.2 DEPS=LOWEST WITH_COVERAGE="true" make tests-dox
+PHP_VERSION=7.2 DEPS=LOWEST WITH_COVERAGE="true" make tests-dox
 ```
 
 Run `make help` to list all available tasks.


### PR DESCRIPTION
fix: remove stray `$` character

Removed a stray `$` character that was causing issues when copying and pasting the code into the terminal.

<!--- Provide a general summary of your changes in the Title above -->

## Description

The commit removes a stray $ character from the code that was causing problems when copying and pasting the script into the terminal. 

## Motivation and context

This change is required because the stray $ character was causing an issue when users attempted to copy the code into the terminal. When copied directly, the $ symbol was interpreted incorrectly by the terminal.

## How has this been tested?

I tested the change by:

Copying and pasting the code into a terminal after the $ character was removed.
Verifying that no errors occur during the paste operation and the code runs successfully.
Ensuring that the terminal accepts the pasted code without unexpected behavior.
Testing was done in a local environment on PhpStorm terminal.

## Screenshots (if appropriate)
![Capturar124](https://github.com/user-attachments/assets/97c265c7-b157-41ec-b7c1-97913e730658)

## Checklist:

Go over all the following points before making your PR:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
