### PR TITLE
docs: update Hunspell.md file, forgot to update one line

### DIFF
--- a/docs/content/03_Spellcheckers/02_Hunspell.md
+++ b/docs/content/03_Spellcheckers/02_Hunspell.md
@@ -26,7 +26,7 @@ On **RHEL**, **CentOS**:
 ```sh
 sudo yum install epel-release
 
-$ sudo yum install hunspell
+sudo yum install hunspell
 ```
 On **Debian**, **Ubuntu**:
 ```sh


### PR DESCRIPTION
fix: remove stray `$` character in previous PR

The `$` character was inadvertently left in the code in a previous pull request ([PR #54](https://github.com/tigitz/php-spellchecker/pull/54)), causing issues when copying and pasting the script into the terminal. This commit removes that stray `$` character to prevent errors.

## Description

This commit removes a stray `$` character that was left behind in the previous pull request ([PR #54](https://github.com/tigitz/php-spellchecker/pull/54)). The issue caused the terminal to misinterpret the `$` symbol when copying and pasting the code.

## Motivation and context

This change is necessary because the stray `$` character was causing problems when users copied the code into the terminal. The `$` symbol was incorrectly interpreted by the terminal, causing errors.

## How has this been tested?

I tested this fix by:
- Copying and pasting the code into a terminal after the `$` character was removed.
- Verifying that no errors occurred and the code runs successfully.

Testing was done in a local environment on PhpStorm terminal.

## Screenshots (if appropriate)
![Capturar124](https://github.com/user-attachments/assets/97c265c7-b157-41ec-b7c1-97913e730658)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
