### PR TITLE
fix: MarkdownRemover updates

### DIFF
--- a/src/TextProcessor/MarkdownRemover.php
+++ b/src/TextProcessor/MarkdownRemover.php
@@ -46,18 +46,12 @@ class MarkdownRemover implements TextProcessorInterface
         $output = \Safe\preg_replace('/^\s{0,3}>\s?/', '', $output);
         // Remove reference-style links?
         $output = \Safe\preg_replace('/^\s{1,2}\[(.*?)\]: (\S+)( ".*?")?\s*$/', '', $output);
-        /**
-         * Remove atx-style headers.
-         *
-         *@TODO find a way to merge the two regex below
-         * remove ## Heading ##
-         */
-        $output = \Safe\preg_replace('/^#{1,6}\s+(.*)(\s+#{1,6})$/m', '$1', $output);
-        // remove ## Heading
-        $output = \Safe\preg_replace('/^#{1,6}\s+(.*)$/m', '$1', $output);
-        // Remove emphasis (repeat the line to remove double emphasis)
-        $output = \Safe\preg_replace('/([\*_]{1,3})(\S.*?\S{0,1})\1/', '$2', $output);
-        $output = \Safe\preg_replace('/([\*_]{1,3})(\S.*?\S{0,1})\1/', '$2', $output);
+        // Remove ## Heading
+        $output = \Safe\preg_replace('/^#{1,6}\s+(.*?)(?:\s+#{1,6})?$/m', '$1', $output);
+        // Remove all layers of emphasis
+        while (\Safe\preg_match('/([\*_]{1,3})(\S.*?\S{0,1})\1/', $output)) {
+            $output = \Safe\preg_replace('/([\*_]{1,3})(\S.*?\S{0,1})\1/', '$2', $output);
+        }
         // Remove list items
         $output = \Safe\preg_replace('/^([^\S\r\n]*)\*\s/m', '$1', $output);
         // Remove code blocks

--- a/tests/TextProcessor/MarkdownRemoverTest.php
+++ b/tests/TextProcessor/MarkdownRemoverTest.php
@@ -113,6 +113,22 @@ class MarkdownRemoverTest extends TestCase
         $this->assertSame($expected, (new MarkdownRemover())->process(t($string))->getContent());
     }
 
+    public function testShouldRemoveTripleEmphasis(): void
+    {
+        $string = 'This text is ***really important***.';
+        $expected = 'This text is really important.';
+
+        $this->assertSame($expected, (new MarkdownRemover())->process(t($string))->getContent());
+    }
+
+    public function testShouldRemoveLongerEmphasis(): void
+    {
+        $string = 'This text is ******really important******.';
+        $expected = 'This text is really important.';
+
+        $this->assertSame($expected, (new MarkdownRemover())->process(t($string))->getContent());
+    }
+
     public function testShouldRemoveHorizontalRules(): void
     {
         $string = "Some text on a line\n\n---\n\nA line below";


### PR DESCRIPTION
## Description

- Condense duplicated regex 
- Regex to remove more than 2 layers of emphasis 

## Motivation and context

This contribution is for an open-source project I actively use. It aims to enhance the markdown remover functionality by adding support for removing triple emphasis from text and addressing some TODOs noted in the code comments.

## How has this been tested?

The Docker README instructions didn’t work out of the box for me because Composer required a minimum of PHP 8.2 but 8.1 was being installed. I updated the default PHP version in the Makefile/docker-compose/Dockerfile to use PHP 8.2. Additionally, I encountered warnings related to the Docker configuration. However, I haven’t committed these changes to a separate PR since I’m unsure whether they are actual fixes or specific to my environment.

Tested using:

```bash
make tests-dox
```

## Checklist:

Go over all the following points before making your PR:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
