### PR TITLE
feat: support PHP to 8.4, Symfony 5+ and update deps

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -13,9 +13,9 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           coverage: none
-          tools: php-cs-fixer:3.54.x, cs2pr
+          tools: php-cs-fixer:3.67.x, cs2pr
 
       - name: Restore PHP-CS-Fixer cache
         uses: actions/cache@v4

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ "8.1", "8.3" ]
+        php: [ "8.2", "8.4" ]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,8 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ["8.1", "8.2", "8.3"]
-        stability: [--prefer-lowest, --prefer-stable]
+        include:
+          - php: "8.4"
+            stability: --prefer-stable
+          - php: "8.2"
+            stability: --prefer-lowest
     env:
       PHP_VERSION: ${{ matrix.php }}
       DEPS_STRATEGY: ${{ matrix.stability }}
@@ -46,7 +49,7 @@ jobs:
         
       - name: Run tests
         run: |
-          export WITH_COVERAGE=$(if [[ ("${{ matrix.php }}" = "8.3") && ("${{ matrix.stability }}" = "--prefer-stable") ]]; then echo "true"; else echo "false"; fi)
+          export WITH_COVERAGE=$(if [[ ("${{ matrix.php }}" = "8.4") && ("${{ matrix.stability }}" = "--prefer-stable") ]]; then echo "true"; else echo "false"; fi)
           echo "WITH_COVERAGE=${WITH_COVERAGE}" >> $GITHUB_ENV
           make vendor
           make tests

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -24,8 +24,11 @@ return (new PhpCsFixer\Config())
         'lowercase_cast' => true,
         'method_chaining_indentation' => true,
         'native_function_casing' => true,
-        'native_function_invocation' => ['include' => ['@compiler_optimized']],
-        'new_with_braces' => true,
+        'native_function_invocation' => [
+            'include' => ['@compiler_optimized'],
+            'strict' => false
+        ],
+        'new_with_parentheses' => true,
         'modernize_types_casting' => true,
         'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
         'no_empty_statement' => true,

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,7 +3,7 @@ build:
         analysis:
             environment:
                 php:
-                    version: 8.1
+                    version: 8.4
             cache:
                 disabled: false
                 directories:

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "tigitz/php-spellchecker",
     "type": "library",
+    "version": "0.8.0",
     "description": "Provides an easy way to spellcheck multiple text source by many spellcheckers, directly from PHP",
     "keywords": [
         "spelling",
@@ -21,11 +22,10 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "nyholm/psr7": "^1.3",
         "psr/http-client": "^1.0",
-        "symfony/process": "^4.4.30 | ^5.0 |^6.0 | ^7.0",
-        "thecodingmachine/safe": "^1.0 | ^2.0",
+        "symfony/process": "^6.4 | ^7",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {
@@ -33,16 +33,15 @@
         "cocur/slugify": "^3.2 || ^4.0",
         "erusev/parsedown": "^1.7",
         "erusev/parsedown-extra": "^0.8",
-        "phpstan/phpstan": "^1.2.0",
-        "phpstan/phpstan-strict-rules": "^1.1.0",
-        "phpstan/phpstan-webmozart-assert": "^1.0.0",
-        "phpstan/phpstan-phpunit": "^1.0.0",
-        "phpunit/phpunit": "^9.5",
-        "pixelrobin/php-feather": "^1.0",
-        "symfony/filesystem": "^4.4 || ^5.0 || ^6.0",
-        "symfony/finder": "^4.4 || ^5.0 || ^6.0",
-        "symfony/http-client": "^5.0 || ^6.0",
-        "thecodingmachine/phpstan-safe-rule": "^1.1"
+        "phpstan/phpstan": "^2",
+        "phpstan/phpstan-strict-rules": "^2",
+        "phpstan/phpstan-webmozart-assert": "^2",
+        "phpstan/phpstan-phpunit": "^2",
+        "phpunit/phpunit": "^11.0",
+        "pixelrobin/php-feather": "^2",
+        "symfony/filesystem": "^5 |^6 | ^7",
+        "symfony/finder": "^5 |^6 | ^7",
+        "symfony/http-client": "^5 |^6 | ^7"
     },
     "suggest": {
         "symfony/http-client": "A PSR-18 Client implementation to use spellcheckers that relies on HTTP APIs"
@@ -51,7 +50,7 @@
         "psr-4": {
             "PhpSpellcheck\\": "src"
         },
-        "files": [ "src/Text/functions.php" ]
+        "files": [ "src/Text/functions.php" , "src/Utils/php-functions.php" ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 services:
   php:
-    image: tigitz/phpspellchecker:${PHP_VERSION:-8.1}
+    image: tigitz/phpspellchecker:${PHP_VERSION:-8.4}
     build:
       context: docker/php
       args:
-        PHP_VERSION: ${PHP_VERSION:-8.1}
+        PHP_VERSION: ${PHP_VERSION:-8.4}
     volumes:
       - .:/usr/src/myapp
       - ./cache:/root/composer/cache

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -26,16 +26,19 @@ RUN apt-get update \
      aspell-en \
      aspell-ru \
      libpspell-dev
-RUN set -eux; \
-      case "$PHP_VERSION" in \
-          8.1*) pecl install xdebug-3.1.1;; \
-          *) pecl install xdebug-3.3.2;; \
-      esac
-RUN docker-php-ext-configure pspell \
-	&& docker-php-ext-enable xdebug \
-    && docker-php-ext-install pspell \
-    && docker-php-ext-install zip \
-    && rm -r /var/lib/apt/lists/*
+
+RUN pecl channel-update pecl.php.net && \
+    pecl install xdebug-3.4.0 && \
+    docker-php-ext-enable xdebug
+
+RUN if [ "${PHP_VERSION}" = "8.4" ]; then \
+        pecl install pspell; \
+    else \
+        docker-php-ext-configure pspell && \
+        docker-php-ext-install pspell; \
+    fi && \
+    docker-php-ext-enable pspell && \
+    rm -r /var/lib/apt/lists/*
 
 RUN cp /usr/share/hunspell/en_US.aff  /usr/share/hunspell/en_US.aff.orig \
     && cp /usr/share/hunspell/en_US.dic  /usr/share/hunspell/en_US.dic.orig \

--- a/docs/generate-docs.php
+++ b/docs/generate-docs.php
@@ -107,11 +107,11 @@ foreach ($filesTree as $item) {
 }
 
 // Generate index.html doc file from the readme while stripping some sections
-$readme = \Safe\file_get_contents(__DIR__.'/../README.md');
+$readme = \PhpSpellcheck\file_get_contents(__DIR__.'/../README.md');
 
-$readme = \Safe\preg_replace('/(# Install[\s\S]+?)^# /m', '# ', $readme);
-$readme = \Safe\preg_replace('/(# Usage[\s\S]+?)^# /m', '# ', $readme);
-$readme = \Safe\preg_replace('/(# Testing[\s\S]+?)^# /m', '# ', $readme);
+$readme = \PhpSpellcheck\preg_replace('/(# Install[\s\S]+?)^# /m', '# ', $readme);
+$readme = \PhpSpellcheck\preg_replace('/(# Usage[\s\S]+?)^# /m', '# ', $readme);
+$readme = \PhpSpellcheck\preg_replace('/(# Testing[\s\S]+?)^# /m', '# ', $readme);
 
 $fs->dumpFile(
     __DIR__.'/index.html',

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,6 @@
 includes:
     - vendor/phpstan/phpstan-webmozart-assert/extension.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon
-    - vendor/thecodingmachine/phpstan-safe-rule/phpstan-safe-rule.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon
 
 parameters:
@@ -24,41 +23,19 @@ parameters:
             path: src/MisspellingHandler/MisspellingHandlerInterface.php
 
         -
-            message: "#^Function pspell_config_create is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add 'use function Safe\\\\pspell_config_create;' at the beginning of the file to use the variant provided by the 'thecodingmachine/safe' library\\.$#"
+            message: '#^Default value of the parameter \#2 \$flags \(0\) of function PhpSpellcheck\\json_encode\(\) is incompatible with type int\<1, max\>\.$#'
+            identifier: parameter.defaultValue
             count: 1
-            path: src/Spellchecker/PHPPspell.php
+            path: src/Utils/php-functions.php
 
         -
-            message: "#^Function pspell_config_ignore is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add 'use function Safe\\\\pspell_config_ignore;' at the beginning of the file to use the variant provided by the 'thecodingmachine/safe' library\\.$#"
+            message: '#^Parameter \#3 \$depth of function json_decode expects int\<1, max\>, int given\.$#'
+            identifier: argument.type
             count: 1
-            path: src/Spellchecker/PHPPspell.php
+            path: src/Utils/php-functions.php
 
         -
-            message: "#^Function pspell_config_mode is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add 'use function Safe\\\\pspell_config_mode;' at the beginning of the file to use the variant provided by the 'thecodingmachine/safe' library\\.$#"
+            message: '#^Parameter \#3 \$depth of function json_encode expects int\<1, max\>, int given\.$#'
+            identifier: argument.type
             count: 1
-            path: src/Spellchecker/PHPPspell.php
-
-        -
-            message: "#^Function pspell_new_config is unsafe to use\\. It can return FALSE instead of throwing an exception\\. Please add 'use function Safe\\\\pspell_new_config;' at the beginning of the file to use the variant provided by the 'thecodingmachine/safe' library\\.$#"
-            count: 1
-            path: src/Spellchecker/PHPPspell.php
-
-        -
-            message: "#^Parameter \\#1 \\$dictionary of function pspell_check expects PSpell\\\\Dictionary, PSpell\\\\Dictionary\\|false given\\.$#"
-            count: 1
-            path: src/Spellchecker/PHPPspell.php
-
-        -
-            message: "#^Parameter \\#1 \\$dictionary of function pspell_check expects PSpell\\\\Dictionary, int given\\.$#"
-            count: 1
-            path: src/Spellchecker/PHPPspell.php
-
-        -
-            message: "#^Parameter \\#1 \\$dictionary of function pspell_suggest expects PSpell\\\\Dictionary, PSpell\\\\Dictionary\\|false given\\.$#"
-            count: 1
-            path: src/Spellchecker/PHPPspell.php
-
-        -
-            message: "#^Parameter \\#1 \\$dictionary of function pspell_suggest expects PSpell\\\\Dictionary, int given\\.$#"
-            count: 1
-            path: src/Spellchecker/PHPPspell.php
+            path: src/Utils/php-functions.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,23 +2,15 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="tests/bootstrap.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
+         stderr="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
          failOnRisky="true"
          failOnWarning="true"
-         stopOnFailure="false"
 >
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
   <php>
     <ini name="error_reporting" value="-1"/>
     <ini name="memory_limit" value="-1"/>
@@ -35,4 +27,10 @@
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Exception/FilesystemException.php
+++ b/src/Exception/FilesystemException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpSpellcheck\Exception;
+
+class FilesystemException extends \ErrorException implements ExceptionInterface
+{
+    public static function createFromPhpError(): self
+    {
+        $error = error_get_last();
+
+        return new self($error['message'] ?? 'An error occured', 0, $error['type'] ?? 1);
+    }
+}

--- a/src/Exception/JsonException.php
+++ b/src/Exception/JsonException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpSpellcheck\Exception;
+
+class JsonException extends \JsonException implements ExceptionInterface
+{
+    public static function createFromPhpError(): self
+    {
+        return new self(json_last_error_msg(), json_last_error());
+    }
+}

--- a/src/Exception/PcreException.php
+++ b/src/Exception/PcreException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpSpellcheck\Exception;
+
+class PcreException extends \Exception implements ExceptionInterface
+{
+    public static function createFromPhpError(): self
+    {
+        $errorMap = [
+            PREG_INTERNAL_ERROR => 'PREG_INTERNAL_ERROR: Internal error',
+            PREG_BACKTRACK_LIMIT_ERROR => 'PREG_BACKTRACK_LIMIT_ERROR: Backtrack limit reached',
+            PREG_RECURSION_LIMIT_ERROR => 'PREG_RECURSION_LIMIT_ERROR: Recursion limit reached',
+            PREG_BAD_UTF8_ERROR => 'PREG_BAD_UTF8_ERROR: Invalid UTF8 character',
+            PREG_BAD_UTF8_OFFSET_ERROR => 'PREG_BAD_UTF8_OFFSET_ERROR',
+            PREG_JIT_STACKLIMIT_ERROR => 'PREG_JIT_STACKLIMIT_ERROR',
+        ];
+        $errMsg = $errorMap[preg_last_error()] ?? 'Unknown PCRE error: '.preg_last_error();
+
+        return new self($errMsg, preg_last_error());
+    }
+}

--- a/src/Exception/ProcessFailedException.php
+++ b/src/Exception/ProcessFailedException.php
@@ -15,13 +15,13 @@ class ProcessFailedException extends \RuntimeException implements ExceptionInter
 
     public function __construct(
         Process $process,
-        \Throwable $previous = null,
+        ?\Throwable $previous = null,
         string $failureReason = '',
         int $code = 0
     ) {
         $this->process = $process;
 
-        $message = \Safe\sprintf(
+        $message = \sprintf(
             'Process with command "%s" has failed%s with exit code %d(%s)%s',
             $process->getCommandLine(),
             $process->isStarted() ? ' running' : '',

--- a/src/Exception/ProcessHasErrorOutputException.php
+++ b/src/Exception/ProcessHasErrorOutputException.php
@@ -20,7 +20,7 @@ class ProcessHasErrorOutputException extends \RuntimeException implements Except
             MSG;
 
         parent::__construct(
-            \Safe\sprintf(
+            \sprintf(
                 $exceptionTemplateMessage,
                 $errorOutput,
                 $command,

--- a/src/Exception/PspellException.php
+++ b/src/Exception/PspellException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpSpellcheck\Exception;
+
+class PspellException extends \ErrorException implements ExceptionInterface
+{
+    public static function createFromPhpError(): self
+    {
+        $error = error_get_last();
+
+        return new self($error['message'] ?? 'An error occurred', 0, $error['type'] ?? 1);
+    }
+}

--- a/src/Misspelling.php
+++ b/src/Misspelling.php
@@ -57,7 +57,7 @@ class Misspelling implements MisspellingInterface
     public function mergeSuggestions(array $suggestionsToAdd): MisspellingInterface
     {
         $mergedSuggestions = [];
-        $existingSuggestionsAsKeys = \Safe\array_flip($this->suggestions);
+        $existingSuggestionsAsKeys = array_flip($this->suggestions);
         foreach ($suggestionsToAdd as $suggestionToAdd) {
             if (!isset($existingSuggestionsAsKeys[$suggestionToAdd])) {
                 $this->suggestions[] = $suggestionToAdd;

--- a/src/MisspellingHandler/EchoHandler.php
+++ b/src/MisspellingHandler/EchoHandler.php
@@ -14,13 +14,13 @@ class EchoHandler implements MisspellingHandlerInterface
     public function handle(iterable $misspellings): void
     {
         foreach ($misspellings as $misspelling) {
-            $output = sprintf(
+            $output = \sprintf(
                 'word: %s | line: %d | offset: %d | suggestions: %s | context: %s' . PHP_EOL,
                 $misspelling->getWord(),
                 $misspelling->getLineNumber(),
                 $misspelling->getOffset(),
                 $misspelling->hasSuggestions() ? implode(',', $misspelling->getSuggestions()) : '',
-                \Safe\json_encode($misspelling->getContext())
+                \PhpSpellcheck\json_encode($misspelling->getContext())
             );
 
             echo $output;

--- a/src/Source/Directory.php
+++ b/src/Source/Directory.php
@@ -62,7 +62,7 @@ class Directory implements SourceInterface
                 // When regex pattern is used, an array containing the file path in its first element is returned
                 $file = new \SplFileInfo(current($file));
             } else {
-                throw new RuntimeException(\Safe\sprintf('Couldn\'t create "%s" object from the given file', \SplFileInfo::class));
+                throw new RuntimeException(\sprintf('Couldn\'t create "%s" object from the given file', \SplFileInfo::class));
             }
 
             if (!$file->isDir() && $file->getRealPath() !== false) {

--- a/src/Source/File.php
+++ b/src/Source/File.php
@@ -25,13 +25,13 @@ class File implements SourceInterface
      */
     public function toTexts(array $context = []): iterable
     {
-        $context['filePath'] = \Safe\realpath($this->filePath);
+        $context['filePath'] = \PhpSpellcheck\realpath($this->filePath);
 
         yield new Text($this->getFileContent(), $context);
     }
 
     private function getFileContent(): string
     {
-        return \Safe\file_get_contents($this->filePath);
+        return \PhpSpellcheck\file_get_contents($this->filePath);
     }
 }

--- a/src/Spellchecker/Aspell.php
+++ b/src/Spellchecker/Aspell.php
@@ -69,7 +69,7 @@ class Aspell implements SpellcheckerInterface
             $languages[$name] = true;
         }
         $languages = array_keys($languages);
-        \Safe\sort($languages);
+        sort($languages);
 
         return $languages;
     }

--- a/src/Spellchecker/Hunspell.php
+++ b/src/Spellchecker/Hunspell.php
@@ -68,7 +68,7 @@ class Hunspell implements SpellcheckerInterface
         foreach ($output as $line) {
             $line = trim($line);
             if ('' === $line // Skip empty lines
-                || \Safe\substr($line, -1) === ':' // Skip headers
+                || substr($line, -1) === ':' // Skip headers
                 || strpos($line, ':') !== false // Skip search path
             ) {
                 continue;
@@ -78,11 +78,13 @@ class Hunspell implements SpellcheckerInterface
                 // Skip MySpell hyphen files
                 continue;
             }
-            $name = \Safe\preg_replace('/\.(aff|dic)$/', '', $name);
-            $languages[$name] = true;
+            $name = \PhpSpellcheck\preg_replace('/\.(aff|dic)$/', '', $name);
+            if (\is_string($name)) {
+                $languages[$name] = true;
+            }
         }
         $languages = array_keys($languages);
-        \Safe\sort($languages);
+        sort($languages);
 
         return $languages;
     }

--- a/src/Spellchecker/Ispell.php
+++ b/src/Spellchecker/Ispell.php
@@ -101,7 +101,7 @@ class Ispell implements SpellcheckerInterface
                     continue;
                 }
 
-                yield \Safe\substr($file, 0, -4);
+                yield substr($file, 0, -4);
             }
         }
 

--- a/src/Spellchecker/LanguageTool.php
+++ b/src/Spellchecker/LanguageTool.php
@@ -42,6 +42,15 @@ class LanguageTool implements SpellcheckerInterface
         }
         $check = $this->apiClient->spellCheck($text, $languages, $options ?? []);
 
+        /** @var array{matches: list<array{
+         *   offset: int,
+         *   context: array{text: string, offset: int, length: int},
+         *   replacements: list<array{value: string}>,
+         *   sentence: string,
+         *   message: string,
+         *   rule: string
+         * }>} $check */
+
         if (!\is_array($check['matches'])) {
             throw new RuntimeException('LanguageTool spellcheck response must contain a "matches" array');
         }

--- a/src/Spellchecker/LanguageTool/LanguageToolApiClient.php
+++ b/src/Spellchecker/LanguageTool/LanguageToolApiClient.php
@@ -23,7 +23,14 @@ class LanguageToolApiClient
      * @param array<string> $languages
      * @param array<mixed> $options
      *
-     * @return array<string, mixed>
+     * @return array{matches: array<array{
+     *   offset: int,
+     *   context: array{text: string, offset: int, length: int},
+     *   replacements: array<array{value: string}>,
+     *   sentence: string,
+     *   message: string,
+     *   rule: string
+     * }>}
      */
     public function spellCheck(string $text, array $languages, array $options): array
     {
@@ -34,6 +41,7 @@ class LanguageToolApiClient
             $options['altLanguages'] = implode(',', $languages);
         }
 
+        /** @var array{matches: array<array{offset: int, context: array{text: string, offset: int, length: int}, replacements: array<array{value: string}>, sentence: string, message: string, rule: string}>} */
         return $this->requestAPI(
             '/v2/check',
             'POST',
@@ -47,14 +55,15 @@ class LanguageToolApiClient
      */
     public function getSupportedLanguages(): array
     {
-        return array_column(
+        /** @var array<string> */
+        return array_values(array_unique(array_column(
             $this->requestAPI(
                 '/v2/languages',
                 'GET',
                 'Accept: application/json'
             ),
             'longCode'
-        );
+        )));
     }
 
     /**
@@ -75,9 +84,9 @@ class LanguageToolApiClient
             $httpData['content'] = http_build_query($queryParams);
         }
 
-        $content = \Safe\file_get_contents($this->baseUrl . $endpoint, false, stream_context_create(['http' => $httpData]));
+        $content = \PhpSpellcheck\file_get_contents($this->baseUrl . $endpoint, false, stream_context_create(['http' => $httpData]));
         /** @var array<mixed> $contentAsArray */
-        $contentAsArray = \Safe\json_decode($content, true);
+        $contentAsArray = \PhpSpellcheck\json_decode($content, true);
 
         return $contentAsArray;
     }

--- a/src/TextProcessor/MarkdownRemover.php
+++ b/src/TextProcessor/MarkdownRemover.php
@@ -17,53 +17,53 @@ class MarkdownRemover implements TextProcessorInterface
     public function process(TextInterface $text): TextInterface
     {
         // Horizontal rules (stripListHeaders conflict with this rule, which is why it has been moved to the top)
-        $output = \Safe\preg_replace('/^(-\s*?|\*\s*?|_\s*?){3,}(\s*)$/m', PHP_EOL . '$2', $text->getContent());
+        $output = \PhpSpellcheck\preg_replace('/^(-\s*?|\*\s*?|_\s*?){3,}(\s*)$/m', PHP_EOL . '$2', $text->getContent());
 
         // Github Flavored Markdown
         // Header
-        $output = \Safe\preg_replace('/\n={2,}/', '\n', $output);
+        $output = \PhpSpellcheck\preg_replace('/\n={2,}/', '\n', $output);
         /**
          * Fenced codeblocks.
          *
          *@TODO parse programming language comments from codeblock instead of removing whole block
          */
-        $output = \Safe\preg_replace('/~{3}.*\n/', '', $output);
+        $output = \PhpSpellcheck\preg_replace('/~{3}.*\n/', '', $output);
         // Strikethrough
-        $output = \Safe\preg_replace('/~~/', '', $output);
+        $output = \PhpSpellcheck\preg_replace('/~~/', '', $output);
         // Common Markdown
         // Remove HTML tags
-        $output = \Safe\preg_replace('/<[^>]*>/', '', $output);
+        $output = \PhpSpellcheck\preg_replace('/<[^>]*>/', '', $output);
         // Remove setext-style headers
-        $output = \Safe\preg_replace('/^[=\-]{2,}\s*$/', '', $output);
+        $output = \PhpSpellcheck\preg_replace('/^[=\-]{2,}\s*$/', '', $output);
         // Remove footnotes?
-        $output = \Safe\preg_replace('/\[\^.+?\](\: .*?$)?/', '', $output);
-        $output = \Safe\preg_replace('/\s{0,2}\[.*?\]: .*?$/', '', $output);
+        $output = \PhpSpellcheck\preg_replace('/\[\^.+?\](\: .*?$)?/', '', $output);
+        $output = \PhpSpellcheck\preg_replace('/\s{0,2}\[.*?\]: .*?$/', '', $output);
         // Remove images
-        $output = \Safe\preg_replace('/\!\[(.*?)\][\[\(].*?[\]\)]/', '$1', $output);
+        $output = \PhpSpellcheck\preg_replace('/\!\[(.*?)\][\[\(].*?[\]\)]/', '$1', $output);
         // Remove inline links
-        $output = \Safe\preg_replace('/\[(.*?)\][\[\(].*?[\]\)]/', '$1', $output);
+        $output = \PhpSpellcheck\preg_replace('/\[(.*?)\][\[\(].*?[\]\)]/', '$1', $output);
         // Remove blockquotes
-        $output = \Safe\preg_replace('/^\s{0,3}>\s?/', '', $output);
+        $output = \PhpSpellcheck\preg_replace('/^\s{0,3}>\s?/', '', $output);
         // Remove reference-style links?
-        $output = \Safe\preg_replace('/^\s{1,2}\[(.*?)\]: (\S+)( ".*?")?\s*$/', '', $output);
+        $output = \PhpSpellcheck\preg_replace('/^\s{1,2}\[(.*?)\]: (\S+)( ".*?")?\s*$/', '', $output);
         /**
          * Remove atx-style headers.
          *
          *@TODO find a way to merge the two regex below
          * remove ## Heading ##
          */
-        $output = \Safe\preg_replace('/^#{1,6}\s+(.*)(\s+#{1,6})$/m', '$1', $output);
+        $output = \PhpSpellcheck\preg_replace('/^#{1,6}\s+(.*)(\s+#{1,6})$/m', '$1', $output);
         // remove ## Heading
-        $output = \Safe\preg_replace('/^#{1,6}\s+(.*)$/m', '$1', $output);
+        $output = \PhpSpellcheck\preg_replace('/^#{1,6}\s+(.*)$/m', '$1', $output);
         // Remove emphasis (repeat the line to remove double emphasis)
-        $output = \Safe\preg_replace('/([\*_]{1,3})(\S.*?\S{0,1})\1/', '$2', $output);
-        $output = \Safe\preg_replace('/([\*_]{1,3})(\S.*?\S{0,1})\1/', '$2', $output);
+        $output = \PhpSpellcheck\preg_replace('/([\*_]{1,3})(\S.*?\S{0,1})\1/', '$2', $output);
+        $output = \PhpSpellcheck\preg_replace('/([\*_]{1,3})(\S.*?\S{0,1})\1/', '$2', $output);
         // Remove list items
-        $output = \Safe\preg_replace('/^([^\S\r\n]*)\*\s/m', '$1', $output);
+        $output = \PhpSpellcheck\preg_replace('/^([^\S\r\n]*)\*\s/m', '$1', $output);
         // Remove code blocks
-        $output = \Safe\preg_replace('/^`{3,}(.*)*$/m', '', $output);
+        $output = \PhpSpellcheck\preg_replace('/^`{3,}(.*)*$/m', '', $output);
         // Remove inline code
-        $output = \Safe\preg_replace('/`(.+?)`/', '$1', $output);
+        $output = \PhpSpellcheck\preg_replace('/`(.+?)`/', '$1', $output);
 
         return $text->replaceContent($output);
     }

--- a/src/Utils/CommandLine.php
+++ b/src/Utils/CommandLine.php
@@ -24,7 +24,7 @@ class CommandLine
             $this->commandArgs = [$command];
         } else {
             throw new InvalidArgumentException(
-                \Safe\sprintf(
+                \sprintf(
                     'Command should be an "array<string>" or a "string", "%s" given',
                     \is_object($command) ? \get_class($command) : \gettype($command)
                 )
@@ -81,10 +81,10 @@ class CommandLine
         if (false !== strpos($argument, "\0")) {
             $argument = str_replace("\0", '?', $argument);
         }
-        if (\Safe\preg_match('/[\/()%!^"<>&|\s]/', $argument) !== 0) {
+        if (\PhpSpellcheck\preg_match('/[\/()%!^"<>&|\s]/', $argument) !== 0) {
             return $argument;
         }
-        $argument = \Safe\preg_replace('/(\\\\+)$/', '$1$1', $argument);
+        $argument = \PhpSpellcheck\preg_replace('/(\\\\+)$/', '$1$1', $argument);
 
         return '"' . str_replace(['"', '^', '%', '!', "\n"], ['""', '"^^"', '"^%"', '"^!"', '!LF!'], $argument) . '"';
     }

--- a/src/Utils/IspellParser.php
+++ b/src/Utils/IspellParser.php
@@ -73,6 +73,6 @@ class IspellParser
      */
     public static function adaptInputForTerseModeProcessing(string $input): string
     {
-        return \Safe\preg_replace('/^/m', '^', $input);
+        return \PhpSpellcheck\preg_replace('/^/m', '^', $input);
     }
 }

--- a/src/Utils/LineAndOffset.php
+++ b/src/Utils/LineAndOffset.php
@@ -21,17 +21,17 @@ class LineAndOffset
     public static function findFromFirstCharacterOffset(string $text, int $offsetFromFirstCharacter): array
     {
         // positive offset
-        Assert::greaterThanEq($offsetFromFirstCharacter, 0, \Safe\sprintf('Offset must be a positive integer, "%s" given', $offsetFromFirstCharacter));
+        Assert::greaterThanEq($offsetFromFirstCharacter, 0, \sprintf('Offset must be a positive integer, "%s" given', $offsetFromFirstCharacter));
 
         $textLength = mb_strlen($text);
         if ($textLength < $offsetFromFirstCharacter) {
             throw new InvalidArgumentException(
-                \Safe\sprintf('Offset given "%d" is higher than the string length "%d"', $offsetFromFirstCharacter, $textLength)
+                \sprintf('Offset given "%d" is higher than the string length "%d"', $offsetFromFirstCharacter, $textLength)
             );
         }
 
         $textBeforeOffset = mb_substr($text, 0, $offsetFromFirstCharacter);
-        $line = ((int) \Safe\preg_match_all('/\R/u', $textBeforeOffset, $matches)) + 1;
+        $line = (\PhpSpellcheck\preg_match_all('/\R/u', $textBeforeOffset, $matches)) + 1;
         $offsetOfPreviousLinebreak = mb_strrpos($textBeforeOffset, PHP_EOL, 0);
 
         $offset = $offsetFromFirstCharacter - ($offsetOfPreviousLinebreak !== false ? $offsetOfPreviousLinebreak + 1 : 0);

--- a/src/Utils/ProcessRunner.php
+++ b/src/Utils/ProcessRunner.php
@@ -14,7 +14,7 @@ class ProcessRunner
      * @param float|int|null $timeout The timeout in seconds
      * @param array<string, string> $env
      */
-    public static function run(Process $process, $timeout = null, callable $callback = null, array $env = []): Process
+    public static function run(Process $process, float|int|null $timeout = null, ?callable $callback = null, array $env = []): Process
     {
         $process->setTimeout($timeout);
 

--- a/src/Utils/php-functions.php
+++ b/src/Utils/php-functions.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpSpellcheck;
+
+use PhpSpellcheck\Exception\FilesystemException;
+use PhpSpellcheck\Exception\JsonException;
+use PhpSpellcheck\Exception\PcreException;
+use PhpSpellcheck\Exception\PspellException;
+use PSpell\Config;
+use PSpell\Dictionary;
+
+/**
+ * @template TFlags as int
+ *
+ * @param mixed $matches
+ * @param TFlags $flags
+ *
+ * @param-out (
+ *          TFlags is 1
+ *          ? array<list<string>>
+ *          : (TFlags is 2
+ *              ? list<array<string>>
+ *              : (TFlags is 256|257
+ *                  ? array<list<array{string, int}>>
+ *                  : (TFlags is 258
+ *                      ? list<array<array{string, int}>>
+ *                      : (TFlags is 512|513
+ *                          ? array<list<?string>>
+ *                          : (TFlags is 514
+ *                              ? list<array<?string>>
+ *                              : (TFlags is 770
+ *                                  ? list<array<array{?string, int}>>
+ *                                  : (TFlags is 0 ? array<list<string>> : array<mixed>)
+ *                              )
+ *                          )
+ *                      )
+ *                  )
+ *              )
+ *          )
+ *        ) $matches
+ */
+function preg_match_all(string $pattern, string $subject, &$matches = [], int $flags = 1, int $offset = 0): int
+{
+    error_clear_last();
+    $safeResult = \preg_match_all($pattern, $subject, $matches, $flags, $offset);
+    if ($safeResult === false) {
+        throw PcreException::createFromPhpError();
+    }
+
+    return $safeResult;
+}
+
+/**
+ * @param string|string[] $pattern
+ * @param array<float|int|string>|string $replacement
+ * @param array<float|int|string>|string $subject
+ *
+ * @param-out 0|positive-int $count
+ *
+ * @return ($subject is array ? list<string> : string)
+ */
+function preg_replace(array|string $pattern, array|string $replacement, array|string $subject, int $limit = -1, ?int &$count = null): array|string
+{
+    error_clear_last();
+    $result = \preg_replace($pattern, $replacement, $subject, $limit, $count);
+    if (preg_last_error() !== PREG_NO_ERROR || $result === null) {
+        throw PcreException::createFromPhpError();
+    }
+
+    return $result;
+}
+
+/**
+ * @template TFlags as int-mask<0, 256, 512>
+ *
+ * @param mixed $matches
+ * @param TFlags $flags
+ *
+ * @param-out (
+ *             TFlags is 256
+ *             ? array<array-key, array{string, 0|positive-int}|array{'', -1}>
+ *             : (TFlags is 512
+ *                 ? array<array-key, string|null>
+ *                 : (TFlags is 768
+ *                     ? array<array-key, array{string, 0|positive-int}|array{null, -1}>
+ *                     : array<array-key, string>
+ *                     )
+ *                 )
+ *             ) $matches
+ *
+ * @return 0|1
+ */
+function preg_match(string $pattern, string $subject, &$matches = [], int $flags = 0, int $offset = 0)
+{
+    error_clear_last();
+    $safeResult = \preg_match($pattern, $subject, $matches, $flags, $offset);
+    if ($safeResult === false) {
+        throw PcreException::createFromPhpError();
+    }
+
+    return $safeResult;
+}
+
+/**
+ * @param ?resource $context
+ * @param int<0, max>|null $length
+ */
+function file_get_contents(string $filename, bool $use_include_path = false, $context = null, int $offset = 0, ?int $length = null): string
+{
+    error_clear_last();
+    if ($length !== null) {
+        $safeResult = \file_get_contents($filename, $use_include_path, $context, $offset, $length);
+    } elseif ($offset !== 0) {
+        $safeResult = \file_get_contents($filename, $use_include_path, $context, $offset);
+    } elseif ($context !== null) {
+        $safeResult = \file_get_contents($filename, $use_include_path, $context);
+    } else {
+        $safeResult = \file_get_contents($filename, $use_include_path);
+    }
+    if ($safeResult === false) {
+        throw FilesystemException::createFromPhpError();
+    }
+
+    return $safeResult;
+}
+
+/**
+ * @param ?resource $context
+ */
+function file_put_contents(string $filename, mixed $data, int $flags = 0, $context = null): int
+{
+    error_clear_last();
+    if ($context !== null) {
+        $safeResult = \file_put_contents($filename, $data, $flags, $context);
+    } else {
+        $safeResult = \file_put_contents($filename, $data, $flags);
+    }
+    if ($safeResult === false) {
+        throw FilesystemException::createFromPhpError();
+    }
+
+    return $safeResult;
+}
+
+function realpath(string $path): string
+{
+    error_clear_last();
+    $safeResult = \realpath($path);
+    if ($safeResult === false) {
+        throw FilesystemException::createFromPhpError();
+    }
+
+    return $safeResult;
+}
+
+/**
+ * @param int<1, max> $flags
+ */
+function json_encode(mixed $value, int $flags = 0, int $depth = 512): string
+{
+    error_clear_last();
+    $safeResult = \json_encode($value, $flags, $depth);
+    if ($safeResult === false) {
+        throw JsonException::createFromPhpError();
+    }
+
+    return $safeResult;
+}
+
+function json_decode(string $json, bool $assoc = false, int $depth = 512, int $flags = 0): mixed
+{
+    $data = \json_decode($json, $assoc, $depth, $flags);
+    if (JSON_ERROR_NONE !== json_last_error()) {
+        throw JsonException::createFromPhpError();
+    }
+
+    return $data;
+}
+
+function pspell_new_config(Config $config): Dictionary
+{
+    error_clear_last();
+    $result = \pspell_new_config($config);
+    if ($result === false) {
+        throw PspellException::createFromPhpError();
+    }
+
+    return $result;
+}

--- a/tests/MisspellingTest.php
+++ b/tests/MisspellingTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use PhpSpellcheck\Exception\InvalidArgumentException;
 use PhpSpellcheck\Misspelling;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class MisspellingTest extends TestCase
 {
@@ -16,15 +17,13 @@ class MisspellingTest extends TestCase
         $this->assertSame(['misspelled', 'misspelling'], $misspelling->getSuggestions());
     }
 
-    /**
-     * @dataProvider nonDeterminableUniqueIdentityMisspellings
-     */
+    #[DataProvider('nonDeterminableUniqueIdentityMisspellings')]
     public function testCanDeterminateUniqueIdentity(Misspelling $misspelling): void
     {
         $this->assertFalse($misspelling->canDeterminateUniqueIdentity());
     }
 
-    public function nonDeterminableUniqueIdentityMisspellings(): array
+    public static function nonDeterminableUniqueIdentityMisspellings(): array
     {
         return [
             [new Misspelling('mispelled')],

--- a/tests/Source/FileTest.php
+++ b/tests/Source/FileTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
+use PhpSpellcheck\Exception\FilesystemException;
 use PhpSpellcheck\Source\File;
 use PHPUnit\Framework\TestCase;
-use Safe\Exceptions\FilesystemException;
 
 use function PhpSpellcheck\t;
 

--- a/tests/Spellchecker/AspellTest.php
+++ b/tests/Spellchecker/AspellTest.php
@@ -8,6 +8,7 @@ use PhpSpellcheck\Spellchecker\Aspell;
 use PhpSpellcheck\Tests\TextTest;
 use PhpSpellcheck\Utils\CommandLine;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class AspellTest extends TestCase
 {
@@ -29,25 +30,19 @@ class AspellTest extends TestCase
         $this->assertWorkingSupportedLanguages(self::FAKE_BINARIES_PATH);
     }
 
-    /**
-     * @group integration
-     */
+    #[Group('integration')]
     public function testSpellcheckFromRealBinaries(): void
     {
         $this->assertWorkingSpellcheck(self::realBinaryPath());
     }
 
-    /**
-     * @group integration
-     */
+    #[Group('integration')]
     public function testSpellcheckFromRealBinariesUTF8(): void
     {
         $this->assertWorkingSpellcheckRUText(self::realBinaryPath());
     }
 
-    /**
-     * @group integration
-     */
+    #[Group('integration')]
     public function testGetSupportedLanguagesFromRealBinaries(): void
     {
         $this->assertWorkingSupportedLanguages(self::realBinaryPath());
@@ -55,7 +50,7 @@ class AspellTest extends TestCase
 
     public function getFakeDicts(): array
     {
-        return explode(PHP_EOL, \Safe\file_get_contents(__DIR__ . '/../Fixtures/Aspell/dicts.txt'));
+        return explode(PHP_EOL, \PhpSpellcheck\file_get_contents(__DIR__ . '/../Fixtures/Aspell/dicts.txt'));
     }
 
     public function assertWorkingSupportedLanguages(string $binaries): void

--- a/tests/Spellchecker/HunspellTest.php
+++ b/tests/Spellchecker/HunspellTest.php
@@ -8,6 +8,7 @@ use PhpSpellcheck\Spellchecker\Hunspell;
 use PhpSpellcheck\Tests\TextTest;
 use PhpSpellcheck\Utils\CommandLine;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class HunspellTest extends TestCase
 {
@@ -29,9 +30,7 @@ class HunspellTest extends TestCase
         (new Hunspell(new CommandLine(IspellTest::FAKE_BAD_BINARIES_PATH)))->check('foo');
     }
 
-    /**
-     * @group integration
-     */
+    #[Group('integration')]
     public function testSpellcheckFromRealBinariesLanguage(): void
     {
         $hunspell = new Hunspell(new CommandLine(self::realBinaryPath()));
@@ -39,25 +38,19 @@ class HunspellTest extends TestCase
         $this->assertInstanceOf(Misspelling::class, $misspellings[0]);
     }
 
-    /**
-     * @group integration
-     */
+    #[Group('integration')]
     public function testSpellcheckFromRealBinaries(): void
     {
         $this->assertWorkingSpellcheckENText(self::realBinaryPath(), IspellTest::CONTENT_STUB, ['en_US']);
     }
 
-    /**
-     * @group integration
-     */
+    #[Group('integration')]
     public function testSpellcheckFromRealBinariesUTF8(): void
     {
         $this->assertWorkingSpellcheckRUText(self::realBinaryPath(), TextTest::CONTENT_STUB_RU, ['ru_RU']);
     }
 
-    /**
-     * @group integration
-     */
+    #[Group('integration')]
     public function testGetSupportedLanguagesFromRealBinaries(): void
     {
         $this->assertWorkingSupportedLanguages(self::realBinaryPath());
@@ -65,7 +58,7 @@ class HunspellTest extends TestCase
 
     public function getFakeDicts(): array
     {
-        return explode(PHP_EOL, \Safe\file_get_contents(__DIR__ . '/../Fixtures/Hunspell/dicts.txt'));
+        return explode(PHP_EOL, \PhpSpellcheck\file_get_contents(__DIR__ . '/../Fixtures/Hunspell/dicts.txt'));
     }
 
     /**

--- a/tests/Spellchecker/IspellTest.php
+++ b/tests/Spellchecker/IspellTest.php
@@ -8,6 +8,7 @@ use PhpSpellcheck\Spellchecker\Ispell;
 use PhpSpellcheck\Tests\TextTest;
 use PhpSpellcheck\Utils\CommandLine;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class IspellTest extends TestCase
 {
@@ -32,17 +33,13 @@ class IspellTest extends TestCase
         Ispell::create(self::FAKE_BAD_BINARIES_PATH)->check('bla');
     }
 
-    /**
-     * @group integration
-     */
+    #[Group('integration')]
     public function testSpellcheckFromRealBinaries(): void
     {
         $this->assertWorkingSpellcheck(self::realBinaryPath());
     }
 
-    /**
-     * @group integration
-     */
+    #[Group('integration')]
     public function testGetSupportedLanguagesFromRealBinaries(): void
     {
         $this->assertWorkingSupportedLanguages(self::realBinaryPath(), self::realShellPath());
@@ -55,10 +52,10 @@ class IspellTest extends TestCase
 
     public function getFakeDicts(): array
     {
-        return explode(PHP_EOL, \Safe\file_get_contents(__DIR__ . '/../Fixtures/Ispell/dicts.txt'));
+        return explode(PHP_EOL, \PhpSpellcheck\file_get_contents(__DIR__ . '/../Fixtures/Ispell/dicts.txt'));
     }
 
-    public function assertWorkingSupportedLanguages(string $binaries, string $shellEntryPoint = null): void
+    public function assertWorkingSupportedLanguages(string $binaries, ?string $shellEntryPoint = null): void
     {
         $ispell = new Ispell(
             new CommandLine($binaries),

--- a/tests/Spellchecker/JamSpellTest.php
+++ b/tests/Spellchecker/JamSpellTest.php
@@ -8,14 +8,13 @@ use PhpSpellcheck\Exception\RuntimeException;
 use PhpSpellcheck\Spellchecker\JamSpell;
 use PhpSpellcheck\Tests\TextTest;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpClient\NativeHttpClient;
 use Symfony\Component\HttpClient\Psr18Client;
 
 class JamSpellTest extends TestCase
 {
-    /**
-     * @group integration
-     */
+    #[Group('integration')]
     public function testSpellcheckFromRealAPI(): void
     {
         $misspellings = iterator_to_array(

--- a/tests/Spellchecker/LanguageToolTest.php
+++ b/tests/Spellchecker/LanguageToolTest.php
@@ -8,6 +8,7 @@ use PhpSpellcheck\Spellchecker\LanguageTool\LanguageToolApiClient;
 use PhpSpellcheck\Tests\TextTest;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class LanguageToolTest extends TestCase
 {
@@ -78,17 +79,13 @@ class LanguageToolTest extends TestCase
         $this->assertWorkingSupportedLanguages($client);
     }
 
-    /**
-     * @group integration
-     */
+    #[Group('integration')]
     public function testSpellcheckFromRealAPI(): void
     {
         $this->assertWorkingSpellcheck(new LanguageToolApiClient(self::realAPIEndpoint()));
     }
 
-    /**
-     * @group integration
-     */
+    #[Group('integration')]
     public function testSpellcheckMultiBytesStringFromRealAPI(): void
     {
         $misspellings = iterator_to_array(
@@ -113,9 +110,7 @@ class LanguageToolTest extends TestCase
         $this->assertWorkingSpellcheck(new LanguageToolApiClient(self::realAPIEndpoint()));
     }
 
-    /**
-     * @group integration
-     */
+    #[Group('integration')]
     public function testGetSupportedLanguagesFromRealBinaries(): void
     {
         $this->assertWorkingSupportedLanguages(new LanguageToolApiClient(self::realAPIEndpoint()));

--- a/tests/Spellchecker/MultiSpellcheckerTest.php
+++ b/tests/Spellchecker/MultiSpellcheckerTest.php
@@ -9,6 +9,7 @@ use PhpSpellcheck\Spellchecker\LanguageTool\LanguageToolApiClient;
 use PhpSpellcheck\Spellchecker\MultiSpellchecker;
 use PhpSpellcheck\Spellchecker\SpellcheckerInterface;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 class MultiSpellcheckerTest extends TestCase
 {
@@ -91,9 +92,7 @@ class MultiSpellcheckerTest extends TestCase
         $this->assertSame(['en', 'fr', 'ru'], $multipleSpellchecker->getSupportedLanguages());
     }
 
-    /**
-     * @group integration
-     */
+    #[Group('integration')]
     public function testGetSupportedLanguage(): void
     {
         $lt = new LanguageTool(new LanguageToolApiClient(LanguageToolTest::realAPIEndpoint()));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,12 +10,12 @@ $dependencies = [
 ];
 
 foreach ($dependencies as $dependency) {
-    echo sprintf('Waiting "%s" dependency'.PHP_EOL, $dependency);
+    echo \sprintf('Waiting "%s" dependency'.PHP_EOL, $dependency);
 
     for (; ;) {
         $url = parse_url(getenv($dependency));
         if ($socket = @fsockopen($url['host'], $url['port'])) {
-            echo sprintf('"%s" dependency is up'.PHP_EOL, $dependency).PHP_EOL;
+            echo \sprintf('"%s" dependency is up'.PHP_EOL, $dependency).PHP_EOL;
             fclose($socket);
 
             break;

--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "php": "^8.1",
-        "friendsofphp/php-cs-fixer": "^v3.54.0"
+        "php": "^8.2",
+        "friendsofphp/php-cs-fixer": "^v3.67.0"
     }
 }


### PR DESCRIPTION
- Upgrade minimum PHP version to 8.2 and Symfony framework to version 5+
- Upgrade PHPStan and PHPUnit
- Remove Safe PHP library dependency due to maintenance issues and 8.4 deprecations
- Implement custom safe PHP function wrappers for internal usage
- Update testing strategy to use PHP 8.4 as default, while maintaining compatibility tests for minimum supported versions

BREAKING CHANGE: Drops support for PHP 8.1