### PR TITLE
feat(deps): support PHP 8.5

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ "8.2", "8.4" ]
+        php: [ "8.2", "8.5" ]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: "8.4"
+          - php: "8.5"
             stability: --prefer-stable
           - php: "8.2"
             stability: --prefer-lowest
@@ -49,7 +49,7 @@ jobs:
         
       - name: Run tests
         run: |
-          export WITH_COVERAGE=$(if [[ ("${{ matrix.php }}" = "8.4") && ("${{ matrix.stability }}" = "--prefer-stable") ]]; then echo "true"; else echo "false"; fi)
+          export WITH_COVERAGE=$(if [[ ("${{ matrix.php }}" = "8.5") && ("${{ matrix.stability }}" = "--prefer-stable") ]]; then echo "true"; else echo "false"; fi)
           echo "WITH_COVERAGE=${WITH_COVERAGE}" >> $GITHUB_ENV
           make vendor
           make tests

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,7 +3,7 @@ build:
         analysis:
             environment:
                 php:
-                    version: 8.4
+                    version: 8.5
             cache:
                 disabled: false
                 directories:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOCKER_COMPOSE 	?= docker compose
 EXEC_PHP      	= $(DOCKER_COMPOSE) run --rm php
-PHP_VERSION     ?= 8.4
+PHP_VERSION     ?= 8.5
 DEPS_STRATEGY   ?= --prefer-stable
 COMPOSER      	= $(EXEC_PHP) composer
 WITH_COVERAGE   ?= "FALSE"
@@ -25,7 +25,7 @@ setup: build
 
 .PHONY: build kill setup
 
-PHPUNIT_FLAGS = $(if $(filter 8.4,$(PHP_VERSION)),--display-deprecations,) \
+PHPUNIT_FLAGS = $(if $(filter 8.5,$(PHP_VERSION)),--display-deprecations,) \
                 $(if $(filter true,$(WITH_COVERAGE)),--coverage-clover clover.xml,)
 
 tests: ## Run all tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 services:
   php:
-    image: tigitz/phpspellchecker:${PHP_VERSION:-8.4}
+    image: tigitz/phpspellchecker:${PHP_VERSION:-8.5}
     build:
       context: docker/php
       args:
-        PHP_VERSION: ${PHP_VERSION:-8.4}
+        PHP_VERSION: ${PHP_VERSION:-8.5}
     volumes:
       - .:/usr/src/myapp
       - ./cache:/root/composer/cache

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -28,14 +28,14 @@ RUN apt-get update \
      libpspell-dev
 
 RUN pecl channel-update pecl.php.net && \
-    pecl install xdebug-3.4.0 && \
+    pecl install xdebug-3.5.1 && \
     docker-php-ext-enable xdebug
 
-RUN if [ "${PHP_VERSION}" = "8.4" ]; then \
-        pecl install pspell; \
-    else \
+RUN if [ "${PHP_VERSION}" = "8.2" ] || [ "${PHP_VERSION}" = "8.3" ]; then \
         docker-php-ext-configure pspell && \
         docker-php-ext-install pspell; \
+    else \
+        pecl install pspell; \
     fi && \
     docker-php-ext-enable pspell && \
     rm -r /var/lib/apt/lists/*

--- a/src/Spellchecker/LanguageTool/LanguageToolApiClient.php
+++ b/src/Spellchecker/LanguageTool/LanguageToolApiClient.php
@@ -55,15 +55,14 @@ class LanguageToolApiClient
      */
     public function getSupportedLanguages(): array
     {
-        /** @var array<string> */
-        return array_values(array_unique(array_column(
-            $this->requestAPI(
-                '/v2/languages',
-                'GET',
-                'Accept: application/json'
-            ),
-            'longCode'
-        )));
+        /** @var array<array{longCode: string}> $languages */
+        $languages = $this->requestAPI(
+            '/v2/languages',
+            'GET',
+            'Accept: application/json'
+        );
+
+        return array_values(array_unique(array_column($languages, 'longCode')));
     }
 
     /**

--- a/src/Utils/php-functions.php
+++ b/src/Utils/php-functions.php
@@ -59,7 +59,7 @@ function preg_match_all(string $pattern, string $subject, &$matches = [], int $f
  *
  * @param-out 0|positive-int $count
  *
- * @return ($subject is array ? list<string> : string)
+ * @return ($subject is array ? array<string> : string)
  */
 function preg_replace(array|string $pattern, array|string $replacement, array|string $subject, int $limit = -1, ?int &$count = null): array|string
 {


### PR DESCRIPTION
## Summary

Adds PHP 8.5 support to the library and CI, bringing the project in line with the PHP active-support cycle (PHP 8.5 was released November 2025). Lower bound stays at PHP 8.2.

### Changes
- **Default PHP version**: `Makefile`, `docker-compose.yml` defaults bumped from 8.4 → 8.5
- **Dockerfile**: xdebug 3.4.0 → 3.5.1 (8.5 support added in xdebug 3.5.x); pspell install logic generalized — PECL for PHP 8.4+, bundled extension for 8.2/8.3
- **CI matrices**: `run-tests.yml` (8.5 prefer-stable + 8.2 prefer-lowest), `phpstan.yml` (8.2 + 8.5), `.scrutinizer.yml` (8.5)
- **PHPUnit `--display-deprecations`** flag moved to 8.5 (the new highest version)

### PHPStan fixes
Two type issues surfaced by newer PHPStan releases (the project gitignores `composer.lock`, so CI always picks up the latest):
- `LanguageToolApiClient::getSupportedLanguages()` — typed the `/v2/languages` response shape so `array_unique` receives a guaranteed array of strings
- `preg_replace()` wrapper — return annotation aligned with native PHP behavior (keys are preserved on array input, so it's `array<string>` not `list<string>`)

### Not changed
- `composer.json` — `"php": "^8.2"` already covers 8.5 syntactically; lower bound intentionally preserved (8.2 has security support until end of 2026)
- `symfony/process: ^6.4 | ^7` — already supports the latest Symfony major

## Test plan

- [x] `PHP_VERSION=8.5 make build && make tests` → 94/94 tests pass on PHP 8.5.6 + Symfony 7.4.11, zero deprecations
- [x] `PHP_VERSION=8.2 DEPS_STRATEGY=--prefer-lowest make tests` → 94/94 tests pass on PHP 8.2.31
- [x] `make phpstan` on both 8.2 and 8.5 → 0 errors
- [x] `make examples-test` on 8.5 → all examples run cleanly
- [x] `make phpcs` → 0 fix needed