### PR TITLE
feat(deps): support Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^8.2",
         "nyholm/psr7": "^1.3",
         "psr/http-client": "^1.0",
-        "symfony/process": "^6.4 | ^7",
+        "symfony/process": "^6.4 | ^7 | ^8",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {
@@ -39,9 +39,9 @@
         "phpstan/phpstan-phpunit": "^2",
         "phpunit/phpunit": "^11.0",
         "pixelrobin/php-feather": "^2",
-        "symfony/filesystem": "^5 |^6 | ^7",
-        "symfony/finder": "^5 |^6 | ^7",
-        "symfony/http-client": "^5 |^6 | ^7"
+        "symfony/filesystem": "^5 |^6 | ^7 | ^8",
+        "symfony/finder": "^5 |^6 | ^7 | ^8",
+        "symfony/http-client": "^5 |^6 | ^7 | ^8"
     },
     "suggest": {
         "symfony/http-client": "A PSR-18 Client implementation to use spellcheckers that relies on HTTP APIs"


### PR DESCRIPTION
## Summary

Adds Symfony 8.x to the supported dependency range. Symfony 8.0 was released October 2025 and requires PHP 8.4+; this library's lower bound stays at PHP 8.2 since Composer's platform check filters Symfony 8 out for users below PHP 8.4.

### Changes
- `composer.json`:
  - `require`: `symfony/process: ^6.4 | ^7` → `^6.4 | ^7 | ^8`
  - `require-dev`: `symfony/filesystem`, `symfony/finder`, `symfony/http-client`: `^5 |^6 | ^7` → `^5 |^6 | ^7 | ^8`

### Resolution behavior
- PHP 8.4+ → Composer resolves to Symfony 8.0.x (or older if the consumer app pins lower).
- PHP 8.2/8.3 → Composer resolves to Symfony 7.x or 6.4 (Symfony 8 is filtered by its `php >= 8.4` constraint).

## Test plan

- [x] `PHP_VERSION=8.5 make tests` with Symfony 8.0.11/8.0.8/8.0.9 → 94/94 tests pass
- [x] `PHP_VERSION=8.5 make phpstan` → 0 errors
- [x] `PHP_VERSION=8.5 make examples-test` → all spellcheckers run cleanly
- [x] `PHP_VERSION=8.2 DEPS_STRATEGY=--prefer-lowest make tests` → 94/94 (resolved to Symfony 6.4 / 5.0)
- [x] `PHP_VERSION=8.2 make phpstan` → 0 errors

## Not changed
- CI matrix unchanged — the existing 8.5 prefer-stable job automatically picks up Symfony 8.
- No code change required; existing tests cover the Symfony API surface used by the library.